### PR TITLE
Add some params and can display branch graph.

### DIFF
--- a/denops/@ddu-kinds/git_commit.ts
+++ b/denops/@ddu-kinds/git_commit.ts
@@ -141,6 +141,12 @@ export class Kind extends BaseKind<Params> {
 
   getPreviewer(args: GetPreviewerArguments): Promise<Previewer | undefined> {
     const action = args.item.action as ActionData;
+    if (typeof action.hash === "undefined") {
+      return Promise.resolve({
+        kind: "terminal",
+        cmds: ["echo", "Select line is dummy of graph only."],
+      });
+    }
     return Promise.resolve({
       kind: "terminal",
       cmds: ["git", "show", action.hash],

--- a/denops/@ddu-kinds/git_commit.ts
+++ b/denops/@ddu-kinds/git_commit.ts
@@ -21,6 +21,7 @@ import { fn } from "https://deno.land/x/ddu_vim@v3.4.4/deps.ts";
 
 export type ActionData = {
   cwd: string;
+  graph: string;
   hash: string;
   author: string;
   authDate: string;

--- a/denops/@ddu-sources/git_log.ts
+++ b/denops/@ddu-sources/git_log.ts
@@ -25,7 +25,11 @@ function formatLog(isGraph: boolean): string {
   return baseFormat.join("%x00");
 }
 
-function parseLog(cwd: string, line: string, isGraph: boolean): Item<ActionData> {
+function parseLog(
+  cwd: string,
+  line: string,
+  isGraph: boolean,
+): Item<ActionData> {
   let graph!: string;
   let hash: string;
   let author: string;
@@ -125,7 +129,9 @@ export class Source extends BaseSource<Params, ActionData> {
           .pipeTo(
             new WritableStream<string[]>({
               write: (logs: string[]) => {
-                controller.enqueue(logs.map((line) => parseLog(cwd, line, isGraph)));
+                controller.enqueue(
+                  logs.map((line) => parseLog(cwd, line, isGraph)),
+                );
               },
             }),
           ).finally(() => {

--- a/denops/@ddu-sources/git_log.ts
+++ b/denops/@ddu-sources/git_log.ts
@@ -25,10 +25,16 @@ function formatLog(): string {
 }
 
 function parseLog(cwd: string, line: string): Item<ActionData> {
-  const [graph, hash, author, authDate, committer, commitDate, subject] = line
-    .split(
-      "\x00",
-    );
+  const [
+    graph,
+    hash,
+    author,
+    authDate,
+    committer,
+    commitDate,
+    subject,
+  ] = line.split("\x00");
+
   const action = {
     cwd,
     graph,

--- a/denops/@ddu-sources/git_log.ts
+++ b/denops/@ddu-sources/git_log.ts
@@ -45,7 +45,8 @@ function parseLog(cwd: string, line: string): Item<ActionData> {
     commitDate,
     subject,
   };
-  if (!hash || hash == "") {
+
+  if (typeof hash === "undefined") {
     return {
       kind: "git_log_graph",
       word: "",

--- a/denops/@ddu-sources/git_log.ts
+++ b/denops/@ddu-sources/git_log.ts
@@ -18,8 +18,9 @@ type Params = {
     | "--topo-order";
 };
 
-function formatLog(isGraph: boolean): string {
+function formatLog(): string {
   const baseFormat = [
+    "", // Graph
     "%H", // Hash
     "%aN", // Author
     "%ai", // AuthorDate
@@ -27,7 +28,6 @@ function formatLog(isGraph: boolean): string {
     "%ci", // CommitDate
     "%s", // Subject
   ];
-  if (isGraph) return ["", ...baseFormat].join("%x00");
   return baseFormat.join("%x00");
 }
 
@@ -36,16 +36,7 @@ function parseLog(
   line: string,
   isGraph: boolean,
 ): Item<ActionData> {
-  let graph!: string;
-  let hash: string;
-  let author: string;
-  let authDate: string;
-  let committer: string;
-  let commitDate: string;
-  let subject: string;
-
-  if (isGraph) {
-    [
+    const [
       graph,
       hash,
       author,
@@ -54,16 +45,6 @@ function parseLog(
       commitDate,
       subject,
     ] = line.split("\x00");
-  } else {
-    [
-      hash,
-      author,
-      authDate,
-      committer,
-      commitDate,
-      subject,
-    ] = line.split("\x00");
-  }
 
   const action = {
     cwd,
@@ -119,7 +100,7 @@ export class Source extends BaseSource<Params, ActionData> {
         const { status, stderr, stdout } = new Deno.Command("git", {
           args: [
             "log",
-            "--pretty=" + formatLog(isGraph),
+            "--pretty=" + formatLog(),
             ...args,
           ],
           cwd,

--- a/denops/@ddu-sources/git_log.ts
+++ b/denops/@ddu-sources/git_log.ts
@@ -11,11 +11,11 @@ type Params = {
   cwd?: string;
   isGraph?: boolean;
   isAll?: boolean;
+  isReverse?: boolean;
   commitOrder?:
     | "--date-order"
     | "--author-date-order"
-    | "--topo-order"
-    | "--reverse";
+    | "--topo-order";
 };
 
 function formatLog(isGraph: boolean): string {
@@ -109,10 +109,12 @@ export class Source extends BaseSource<Params, ActionData> {
         const cwd = sourceParams.cwd ?? await fn.getcwd(denops);
         const isGraph = sourceParams.isGraph ?? false;
         const isAll = sourceParams.isAll ?? false;
+        const isReverse = sourceParams.isReverse ?? false;
         const commitOrder = sourceParams.commitOrder ?? "--topo-order";
         let args: string[] = [commitOrder];
         if (isGraph) args = [...args, "--graph"];
         if (isAll) args = [...args, "--all"];
+        if (isReverse) args = [...args, "--reverse"];
 
         const { status, stderr, stdout } = new Deno.Command("git", {
           args: [

--- a/denops/@ddu-sources/git_log.ts
+++ b/denops/@ddu-sources/git_log.ts
@@ -9,6 +9,7 @@ import { ErrorStream } from "../ddu-source-git_log/message.ts";
 
 type Params = {
   cwd?: string;
+  args?: string[];
 };
 
 function formatLog(): string {
@@ -40,10 +41,12 @@ export class Source extends BaseSource<Params, ActionData> {
     return new ReadableStream<Item<ActionData>[]>({
       async start(controller) {
         const cwd = sourceParams.cwd ?? await fn.getcwd(denops);
+        const args = sourceParams.args ?? [];
         const { status, stderr, stdout } = new Deno.Command("git", {
           args: [
             "log",
             "--pretty=" + formatLog(),
+            ...args,
           ],
           cwd,
           stdin: "null",

--- a/denops/@ddu-sources/git_log.ts
+++ b/denops/@ddu-sources/git_log.ts
@@ -48,7 +48,7 @@ function parseLog(cwd: string, line: string): Item<ActionData> {
 
   if (typeof hash === "undefined") {
     return {
-      kind: "git_log_graph",
+      kind: "git_commit",
       word: "",
       display: `${graph}`,
       action,

--- a/denops/@ddu-sources/git_log.ts
+++ b/denops/@ddu-sources/git_log.ts
@@ -9,7 +9,13 @@ import { ErrorStream } from "../ddu-source-git_log/message.ts";
 
 type Params = {
   cwd?: string;
-  args?: string[];
+  isGraph?: boolean;
+  isAll?: boolean;
+  commitOrder?:
+    | "--date-order"
+    | "--author-date-order"
+    | "--topo-order"
+    | "--reverse";
 };
 
 function formatLog(isGraph: boolean): string {
@@ -101,8 +107,13 @@ export class Source extends BaseSource<Params, ActionData> {
     return new ReadableStream<Item<ActionData>[]>({
       async start(controller) {
         const cwd = sourceParams.cwd ?? await fn.getcwd(denops);
-        const args = sourceParams.args ?? [];
-        const isGraph = args.includes("--graph");
+        const isGraph = sourceParams.isGraph ?? false;
+        const isAll = sourceParams.isAll ?? false;
+        const commitOrder = sourceParams.commitOrder ?? "--topo-order";
+        let args: string[] = [commitOrder];
+        if (isGraph) args = [...args, "--graph"];
+        if (isAll) args = [...args, "--all"];
+
         const { status, stderr, stdout } = new Deno.Command("git", {
           args: [
             "log",

--- a/denops/@ddu-sources/git_log.ts
+++ b/denops/@ddu-sources/git_log.ts
@@ -12,16 +12,19 @@ type Params = {
   args?: string[];
 };
 
-function formatLog(): string {
-  return [
-    "", // Graph
+function formatLog(args: string[]): string {
+  const baseFormat = [
     "%H", // Hash
     "%aN", // Author
     "%ai", // AuthorDate
     "%cN", // Commit
     "%ci", // CommitDate
     "%s", // Subject
-  ].join("%x00");
+  ];
+  if (args.includes("--graph")) {
+    return ["", ...baseFormat].join("%x00");
+  }
+  return baseFormat.join("%x00");
 }
 
 function parseLog(cwd: string, line: string): Item<ActionData> {
@@ -73,8 +76,7 @@ export class Source extends BaseSource<Params, ActionData> {
         const { status, stderr, stdout } = new Deno.Command("git", {
           args: [
             "log",
-            "--graph",
-            "--pretty=" + formatLog(),
+            "--pretty=" + formatLog(args),
             ...args,
           ],
           cwd,

--- a/denops/@ddu-sources/git_log.ts
+++ b/denops/@ddu-sources/git_log.ts
@@ -9,9 +9,9 @@ import { ErrorStream } from "../ddu-source-git_log/message.ts";
 
 type Params = {
   cwd?: string;
-  isGraph?: boolean;
-  isAll?: boolean;
-  isReverse?: boolean;
+  showGraph?: boolean;
+  showAll?: boolean;
+  showReverse?: boolean;
   commitOrder?:
     | "--date-order"
     | "--author-date-order"
@@ -88,14 +88,14 @@ export class Source extends BaseSource<Params, ActionData> {
     return new ReadableStream<Item<ActionData>[]>({
       async start(controller) {
         const cwd = sourceParams.cwd ?? await fn.getcwd(denops);
-        const isGraph = sourceParams.isGraph ?? false;
-        const isAll = sourceParams.isAll ?? false;
-        const isReverse = sourceParams.isReverse ?? false;
+        const showGraph = sourceParams.showGraph ?? false;
+        const showAll = sourceParams.showAll ?? false;
+        const showReverse = sourceParams.showReverse ?? false;
         const commitOrder = sourceParams.commitOrder ?? "--topo-order";
         let args: string[] = [commitOrder];
-        if (isGraph) args = [...args, "--graph"];
-        if (isAll) args = [...args, "--all"];
-        if (isReverse) args = [...args, "--reverse"];
+        if (showGraph) args = [...args, "--graph"];
+        if (showAll) args = [...args, "--all"];
+        if (showReverse) args = [...args, "--reverse"];
 
         const { status, stderr, stdout } = new Deno.Command("git", {
           args: [
@@ -124,7 +124,7 @@ export class Source extends BaseSource<Params, ActionData> {
             new WritableStream<string[]>({
               write: (logs: string[]) => {
                 controller.enqueue(
-                  logs.map((line) => parseLog(cwd, line, isGraph)),
+                  logs.map((line) => parseLog(cwd, line, showGraph)),
                 );
               },
             }),

--- a/denops/@ddu-sources/git_log.ts
+++ b/denops/@ddu-sources/git_log.ts
@@ -51,6 +51,7 @@ function parseLog(cwd: string, line: string): Item<ActionData> {
       kind: "git_log_graph",
       word: "",
       display: `${graph}`,
+      action,
     };
   }
   return {

--- a/doc/ddu-source-git_log.txt
+++ b/doc/ddu-source-git_log.txt
@@ -88,13 +88,19 @@ isAll                                         *ddu-source-git_log-param-isAll*
 
 	Default: false
 
+isReverse                                 *ddu-source-git_log-param-isReverse*
+	(boolean)
+	`git log --reverse`
+
+	Default: false
+
+
 commitOrder                             *ddu-source-git_log-param-commitOrder*
 	(string)
 
 	"--date-order": `git log --date-order`
 	"--author-date-order": `git log --author-date-order`
 	"--topo-order": `git log --topo-order`
-	"--reverse": `git log --reverse`
 
 	Default: "--topo-order"
 

--- a/doc/ddu-source-git_log.txt
+++ b/doc/ddu-source-git_log.txt
@@ -71,11 +71,19 @@ You can use with ddu-source-git_diff_tree to source diffs in the commit.
 Source Params ~
                                                    *ddu-source-git_log-params*
 
-cwd
+cwd                                             *ddu-source-git_log-param-cwd*
 	(string)
 	Get commit logs as if git is called in the path instead of the current
 	working directory (like `git -C`).
 
+isGraph                                     *ddu-source-git_log-param-isGraph*
+	(boolean)
+
+isAll                                         *ddu-source-git_log-param-isAll*
+	(boolean)
+
+commitOrder                             *ddu-source-git_log-param-commitOrder*
+	(string)
 
 ==============================================================================
 Actions ~

--- a/doc/ddu-source-git_log.txt
+++ b/doc/ddu-source-git_log.txt
@@ -78,12 +78,25 @@ cwd                                             *ddu-source-git_log-param-cwd*
 
 isGraph                                     *ddu-source-git_log-param-isGraph*
 	(boolean)
+	`git log --graph`
+
+	Default: false
 
 isAll                                         *ddu-source-git_log-param-isAll*
 	(boolean)
+	`git log --all`
+
+	Default: false
 
 commitOrder                             *ddu-source-git_log-param-commitOrder*
 	(string)
+
+	"--date-order": `git log --date-order`
+	"--author-date-order": `git log --author-date-order`
+	"--topo-order": `git log --topo-order`
+	"--reverse": `git log --reverse`
+
+	Default: "--topo-order"
 
 ==============================================================================
 Actions ~

--- a/doc/ddu-source-git_log.txt
+++ b/doc/ddu-source-git_log.txt
@@ -78,7 +78,7 @@ cwd                                             *ddu-source-git_log-param-cwd*
 
 	Default: |getcwd()|
 
-isGraph                                     *ddu-source-git_log-param-isGraph*
+showGraph                                 *ddu-source-git_log-param-showGraph*
 	(boolean)
 	Draw a text-based graphical representation of the commit history on
 	the left hand side of the output.
@@ -86,7 +86,7 @@ isGraph                                     *ddu-source-git_log-param-isGraph*
 
 	Default: false
 
-isAll                                         *ddu-source-git_log-param-isAll*
+showAll                                     *ddu-source-git_log-param-showAll*
 	(boolean)
 	Pretend as if all the refs in refs/, along with HEAD, are listed
 	on the command line as <commit>.
@@ -94,7 +94,7 @@ isAll                                         *ddu-source-git_log-param-isAll*
 
 	Default: false
 
-isReverse                                 *ddu-source-git_log-param-isReverse*
+showReverse                             *ddu-source-git_log-param-showReverse*
 	(boolean)
 	Output the commits shown in reverse order.
 	`git log --reverse`

--- a/doc/ddu-source-git_log.txt
+++ b/doc/ddu-source-git_log.txt
@@ -76,20 +76,27 @@ cwd                                             *ddu-source-git_log-param-cwd*
 	Get commit logs as if git is called in the path instead of the current
 	working directory (like `git -C`).
 
+	Default: |getcwd()|
+
 isGraph                                     *ddu-source-git_log-param-isGraph*
 	(boolean)
-	`git log --graph`
+	Draw a text-based graphical representation of the commit history on
+	the left hand side of the output.
+	NOTE: `git log --graph` of same.
 
 	Default: false
 
 isAll                                         *ddu-source-git_log-param-isAll*
 	(boolean)
-	`git log --all`
+	Pretend as if all the refs in refs/, along with HEAD, are listed
+	on the command line as <commit>.
+	NOTE: `git log --all` of same.
 
 	Default: false
 
 isReverse                                 *ddu-source-git_log-param-isReverse*
 	(boolean)
+	Output the commits shown in reverse order.
 	`git log --reverse`
 
 	Default: false
@@ -97,6 +104,9 @@ isReverse                                 *ddu-source-git_log-param-isReverse*
 
 commitOrder                             *ddu-source-git_log-param-commitOrder*
 	(string)
+	Specifies the sorting order of commits.
+	Check 'Commit Ordering' in `man git-log` for details on the options
+	you can specify.
 
 	"--date-order": `git log --date-order`
 	"--author-date-order": `git log --author-date-order`


### PR DESCRIPTION
## Add some params

Add the following parameters.

* `isGraph`
* `isAll`
* `isReverse`
* `commitOrder`

Check `doc/ddu-source-git_log.txt` for a description of each parameter.
Added default value for parameter `cwd` description in document.
Also, since I added some parameters, I added a helptag to match.

## Could display branch graph

The 'branch graph' is displayed in the source when `isGraph` is `true`.

![git_git_graph](https://github.com/kyoh86/ddu-source-git_log/assets/74786563/fd0ecf0e-56c5-474a-a08b-e1492bd40358)
※this sample is [git/git](https://github.com/git/git).

Regarding the line where only graph is displayed, it was set to `git_commit` of the existing kind.
The reason for this is that I thought that adding kind for graph would not have any special action.
When graph only line previewing display description of 'Select line is dummy of graph only'.

## In the end

Please merge if you like.
Thank you.
